### PR TITLE
Added the 'Open Current File in Sublime Text' shortcut to the File ->…

### DIFF
--- a/src/VSCommands.cs
+++ b/src/VSCommands.cs
@@ -20,6 +20,8 @@ namespace OpenInSublimeText
     internal sealed partial class PackageIds
     {
         public const int OpenInSublimeText = 0x0100;
+        public const int FileOpenMenuGroup = 0x0101;
+        public const int OpenCurrentFileInSublimeText = 0x0102;
         public const int Sublime = 0x0001;
     }
 }

--- a/src/VSCommands.vsct
+++ b/src/VSCommands.vsct
@@ -13,7 +13,21 @@
                     <ButtonText>Open in Sublime Text</ButtonText>
                 </Strings>
             </Button>
+
+            <Button guid="guidOpenInVsCmdSet" id="OpenCurrentFileInSublimeText" priority="0x0500" type="Button">
+                <Parent guid="guidOpenInVsCmdSet" id="FileOpenMenuGroup" />
+                <Icon guid="guidIcons" id="Sublime" />
+                <Strings>
+                    <ButtonText>Current File in Sublime Text</ButtonText>
+                </Strings>
+            </Button>
         </Buttons>
+
+        <Groups>
+            <Group guid="guidOpenInVsCmdSet" id="FileOpenMenuGroup">
+                <Parent guid="guidSHLMainMenu" id="IDM_VS_CSCD_OPEN" />
+            </Group>
+        </Groups>
 
         <Bitmaps>
             <Bitmap guid="guidIcons" usedList="Sublime" href="Resources/logo.png" />
@@ -38,6 +52,8 @@
 
         <GuidSymbol name="guidOpenInVsCmdSet" value="{bcea1810-8ea5-45b9-9df0-7ea5baf757cd}">
             <IDSymbol name="OpenInSublimeText" value="0x0100" />
+            <IDSymbol name="FileOpenMenuGroup" value="0x0101" />
+            <IDSymbol name="OpenCurrentFileInSublimeText" value="0x0102" />
         </GuidSymbol>
 
         <GuidSymbol name="guidIcons" value="{bcea1810-8ea5-45b9-9df0-7ea5baf757ce}">


### PR DESCRIPTION
… Open menu, which opens at the current selected line in Sublime Text.

This is particularly useful when using Visual Studio for compilation and code navigation, and Sublime Text for code editing. You can set up a shortcut in the keys setting menu, so with a press of a button you can open the current open document at the current selected line and start editing right away without any mouse interaction.